### PR TITLE
expose previousFocus as an option

### DIFF
--- a/src/backbone.modal.coffee
+++ b/src/backbone.modal.coffee
@@ -38,8 +38,8 @@
       else
         @viewContainerEl = @modalEl
 
-      $focusEl = Backbone.$(document.activeElement)
-      @previousFocus = $focusEl unless @previousFocus
+      $prevEl = @previousFocus?()
+      @previousFocusEl = Backbone.$(document.activeElement) unless $prevEl
 
       @openAt(options) if @views?.length > 0 and @showViewOnRender
       @onRender?()
@@ -78,6 +78,7 @@
       @views?.length  = _.size(@views)
       @viewContainer  = @getOption('viewContainer')
       @animate        = @getOption('animate')
+      @previousFocus  = @getOption('previousFocus')
 
       # check if everything is right
       throw new Error('No template or views defined for Backbone.Modal') if _.isUndefined(@template) and _.isUndefined(@views)
@@ -289,7 +290,7 @@
       removeViews = =>
         @currentView?.remove?()
         @remove()
-        @previousFocus?.focus?()
+        @previousFocusEl?.focus?()
 
       if @$el.fadeOut and @animate
         @$el.fadeOut(duration: 200)

--- a/test/src/backbone.modal.spec.coffee
+++ b/test/src/backbone.modal.spec.coffee
@@ -99,11 +99,21 @@ describe 'Backbone.Modal', ->
       view = new modal()
       expect((view.render().el instanceof HTMLElement)).toBeTruthy()
 
-    it 'should save a reference to the previously focused element', ->
-      expected = Backbone.$(document.activeElement)
-      view = new modal()
-      view.render()
-      expect(view.previousFocus).toEqual(expected)
+      it 'should save a reference to the previously focused element', ->
+        expected = Backbone.$(document.activeElement)
+        view = new modal()
+        view.render()
+        expect(view.previousFocusEl).toEqual(expected)
+
+    describe 'previousFocus option is defined', ->
+      beforeEach ->
+        modal.previousFocus = -> Backbone.$(document.activeElement)
+
+      it 'should save a reference to the previously focused element', ->
+        expected = Backbone.$(document.activeElement)
+        view = new modal()
+        view.render()
+        expect(view.previousFocusEl).toEqual(expected)
 
     it 'should focus modal div', ->
       view = new modal()


### PR DESCRIPTION
I don't know coffeescript so this may be no good.

Expose `previousFocus` as an option so you can pass a function that should return an element to focus once the modal has closed.